### PR TITLE
fix(setup): Update Physionet 2017 challenge download links

### DIFF
--- a/examples/cinc17/setup.sh
+++ b/examples/cinc17/setup.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-url=https://www.physionet.org/challenge/2017/
+# The original base URL no longer works, we are using direct links.
 
 mkdir data && cd data
 
-curl -O $url/training2017.zip
+# Download training data
+curl -L -o training2017.zip "https://www.physionet.org/files/challenge-2017/1.0.0/training2017.zip?download"
 unzip training2017.zip
-curl -O $url/sample2017.zip
+
+# Download sample data
+curl -L -o sample2017.zip "https://www.physionet.org/files/challenge-2017/1.0.0/sample2017.zip?download"
 unzip sample2017.zip
-curl -O $url/REFERENCE-v3.csv
+
+# Download reference file (NOTE: this is called REFERENCE-v3.csv)
+curl -L -o REFERENCE-v3.csv "https://www.physionet.org/files/challenge-2017/1.0.0/REFERENCE-v3.csv?download"
 
 cd ..
 


### PR DESCRIPTION
### 🔨 Motivation
The original download links used in `setup.sh` for the Physionet Challenge 2017 data were broken and failed to complete the script's execution. This prevented users from successfully setting up the necessary training and sample datasets.

### ✅ Changes
This pull request updates the `setup.sh` file with the new, working, direct download URLs for the following files:

* `training2017.zip`
* `sample2017.zip`
* `REFERENCE-v3.csv`

The script now uses the direct `?download` links from PhysioNet, ensuring the setup process completes successfully.

### 🧪 Testing
The updated `setup.sh` script was executed locally to confirm that:
1.  The `data` directory is created.
2.  All three files (`training2017.zip`, `sample2017.zip`, `REFERENCE-v3.csv`) are downloaded correctly.
3.  The two zip files are successfully unzipped.
4.  The script proceeds to the final step (`python build_datasets.py`) without errors.